### PR TITLE
Fix bug in template

### DIFF
--- a/Source/Mosa.VisualStudio.ProjectTemplate/Boot.cs
+++ b/Source/Mosa.VisualStudio.ProjectTemplate/Boot.cs
@@ -48,8 +48,11 @@ namespace $safeprojectname$
                     switch (keyCode)
                     {
                         case PS2Keyboard.KeyCode.Delete:
-                            Console.RemovePreviousOne();
-                            Input = Input.Substring(0, Input.Length - 1);
+                            if (Input.Length != 0)
+                            {
+                                Console.RemovePreviousOne();
+                                Input = Input.Substring(0, Input.Length - 1);
+                            }
                             break;
 
                         case PS2Keyboard.KeyCode.Enter:


### PR DESCRIPTION
If you backspace while nothing is typed, it will stop the PS2Keyboard from working. This pull request fixes it.